### PR TITLE
Fixed getting event #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 *.pyc
 venv
+.eggs/
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ zip_safe=False,
 packages=['django_eventstream', 'django_eventstream.migrations', 'django_eventstream.management', 'django_eventstream.management.commands'],
 package_data={'django_eventstream': ['static/django_eventstream/*']},
 install_requires=['gripcontrol>=3.1.0,<4', 'django_grip>=1.7,<2', 'Werkzeug>=0.12,<1', 'six>=1.10,<2'],
+tests_require=['Django'],
+test_suite = "tests.runtests.runtests",
 classifiers=[
 	'Development Status :: 4 - Beta',
 	'Topic :: Utilities',

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+def runtests():
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(["tests"])
+    sys.exit(bool(failures))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,13 @@
+SECRET_KEY = 'django_tests_secret_key'
+
+DATABASES={
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+INSTALLED_APPS = [
+    'django_eventstream',
+    'tests',
+]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.test import TestCase
+from django_eventstream.storage import DjangoModelStorage, EventDoesNotExist
+
+
+class DjangoStorageTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.storage = DjangoModelStorage()
+
+    def test_empty_channel_id(self):
+        self.assertEqual(self.storage.get_current_id('empty'), 0)
+
+    def test_empty_channel_events(self):
+        self.assertEqual(self.storage.get_events('empty', 0), [])
+
+    def test_empty_channel_error(self):
+        with self.assertRaises(EventDoesNotExist) as cm:
+            self.storage.get_events('empty', 1)
+        
+        self.assertEqual(cm.exception.current_id, 0)
+
+    def test_append(self):
+        channel = 'channel'
+        data = {'a': 'b'}
+
+        self.storage.append_event(channel, 'message', data)
+
+        self.assertEqual(self.storage.get_current_id(channel), 1)
+        
+        events = self.storage.get_events(channel, 0)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].data, data)
+
+        self.assertEqual(self.storage.get_events(channel, 1), [])
+
+        with self.assertRaises(EventDoesNotExist) as cm:
+            self.storage.get_events(channel, 2)
+        
+        self.assertEqual(cm.exception.current_id, 1)


### PR DESCRIPTION
While writing a storage backend for a document database, I tested `DjangoModelStorage` to understand the expected behavior and I noticed a bug with `get_events` when trying to get event with id 1. After appending the first event, it's impossible to get it as calling `get_events(channel, 0)` raises an exception while `get_events(channel, 1)` returns an empty list. See example code:
```
from django_eventstream.storage import DjangoModelStorage
storage = DjangoModelStorage()
channel = 'my_channel'

data = {'a': 'b'}
s.append_event(channel, 'message', data)
s.get_current_id(channel) # returns 1
s.get_events(channel, 0) # raises an exception
s.get_events(channel, 1) # returns []
```
I added basic tests for the `DjangoModelStorage` class and implemented the fix that's required according to my understanding of the expected behavior.