### PR TITLE
If EVENTSTREAM_ALLOW_ORIGIN is unset, fallback to using ALLOWED_HOSTS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ daphne your_project.asgi:application
 
 See the [Channels Documentation](https://channels.readthedocs.io/en/latest/deploying.html) for information about deployment.
 
+### CORS Support
+
+By default, all event stream responses will use a CORS header built from the `ALLOWED_HOSTS` Django setting.  If a different set of allowed hosts is preferred, you can set `EVENTSTREAM_ALLOW_ORIGIN` in your application's `settings.py` to a list of allowable hostnames.
+
 ### Multiple instances and scaling
 
 If you want to run multiple instances of your Django project for high availablity, or need to be able to scale to a large number of connections, you can introduce a GRIP proxy layer (such as [Pushpin](https://pushpin.org) or [Fanout Cloud](https://fanout.io)) into your architecture.

--- a/django_eventstream/consumers.py
+++ b/django_eventstream/consumers.py
@@ -158,12 +158,12 @@ class EventsConsumer(AsyncHttpConsumer):
 		extra_headers = {}
 		extra_headers['Cache-Control'] = 'no-cache'
 
-		cors_origin = ''
 		if hasattr(settings, 'EVENTSTREAM_ALLOW_ORIGIN'):
 			cors_origin = settings.EVENTSTREAM_ALLOW_ORIGIN
+		else:
+			cors_origin = settings.ALLOWED_HOSTS
 
-		if cors_origin:
-			extra_headers['Access-Control-Allow-Origin'] = cors_origin
+		extra_headers['Access-Control-Allow-Origin'] = cors_origin
 
 		# if this was a grip request or we encountered an error, respond now
 		if response:


### PR DESCRIPTION
… in the CORS header.

It took me a little while to figure out that EVENTSTREAM_ALLOW_ORIGIN was required for my setup.  This change defaults the CORS header to use the ALLOWED_HOSTS value, but still prefers (and documents) the new EVENTSTREAM_ALLOW_ORIGIN setting.