### PR TITLE
save signed metadata in next link

### DIFF
--- a/django_eventstream/consumers.py
+++ b/django_eventstream/consumers.py
@@ -186,10 +186,6 @@ class EventsConsumer(AsyncHttpConsumer):
 
 		await self.send_headers(headers=headers)
 
-		body = b':' + (b' ' * 2048) + b'\n\n'
-		body += b'event: stream-open\ndata:\n\n'
-		await self.send_body(body, more_body=True)
-
 		self.listener = Listener()
 		self.is_streaming = True
 
@@ -205,6 +201,8 @@ class EventsConsumer(AsyncHttpConsumer):
 		lm = get_listener_manager()
 
 		lm.add_listener(self.listener)
+
+		first_result = True
 
 		while self.is_streaming:
 			try:
@@ -223,6 +221,13 @@ class EventsConsumer(AsyncHttpConsumer):
 			event_id = make_id(last_ids)
 
 			body = ''
+
+			if first_result:
+				first_result = False
+
+				# include padding on the first result
+				body += ':' + (' ' * 2048) + '\n\n'
+				body += 'event: stream-open\ndata:\n\n'
 
 			if len(event_response.channel_reset) > 0:
 				body += sse_encode_event(

--- a/django_eventstream/eventresponse.py
+++ b/django_eventstream/eventresponse.py
@@ -1,5 +1,8 @@
 import copy
+import time
+import jwt
 import six
+from django.conf import settings
 from django.http import HttpResponse
 from .utils import sse_encode_event, make_id, build_id_escape
 
@@ -49,6 +52,8 @@ class EventResponse(object):
 
 		more = (len(self.channel_more) > 0)
 
+		user_id = self.user.id if self.user else 'anonymous'
+
 		params = http_request.GET.copy()
 		params['link'] = 'next'
 		if more:
@@ -59,13 +64,18 @@ class EventResponse(object):
 			params['recover'] = 'true'
 			if 'lastEventId' in params:
 				del params['lastEventId']
+		es_meta = {
+			'iss': 'es',
+			'exp': int(time.time()) + 3600,
+			'channels': self.channel_items.keys(),
+			'user': user_id
+		}
+		params['es-meta'] = jwt.encode(es_meta, settings.SECRET_KEY.encode('utf-8'))
 		uri = http_request.path + '?' + params.urlencode()
 		resp['Grip-Link'] = '<%s>; rel=next' % uri
 
 		if not more:
 			resp['Grip-Hold'] = 'stream'
-
-		user_id = self.user.id if self.user else 'anonymous'
 
 		channel_header = ''
 		for channel in six.iterkeys(self.channel_items):

--- a/django_eventstream/eventresponse.py
+++ b/django_eventstream/eventresponse.py
@@ -68,7 +68,7 @@ class EventResponse(object):
 			'iss': 'es',
 			'exp': int(time.time()) + 3600,
 			'channels': self.channel_items.keys(),
-			'user': user_id
+			'user': str(user_id)
 		}
 		params['es-meta'] = jwt.encode(es_meta, settings.SECRET_KEY.encode('utf-8'))
 		uri = http_request.path + '?' + params.urlencode()

--- a/django_eventstream/eventstream.py
+++ b/django_eventstream/eventstream.py
@@ -39,6 +39,9 @@ def send_event(channel, event_type, data, skip_user_ids=[]):
 		skip_user_ids=skip_user_ids)
 
 def get_events(request, limit=100, user=None):
+	if user is None:
+		user = request.user
+
 	resp = EventResponse()
 	resp.is_next = request.is_next
 	resp.is_recover = request.is_recover

--- a/django_eventstream/views.py
+++ b/django_eventstream/views.py
@@ -9,13 +9,9 @@ def events(request, **kwargs):
 	from .eventstream import EventPermissionError, get_events
 	from .utils import sse_error_response
 
-	user = None
-	if request.user.is_authenticated:
-		user = request.user
-
 	try:
 		event_request = EventRequest(request, view_kwargs=kwargs)
-		event_response = get_events(event_request, user=user)
+		event_response = get_events(event_request)
 		response = event_response.to_http_response(request)
 	except EventRequest.ResumeNotAllowedError as e:
 		response = HttpResponseBadRequest(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = []
 if sys.version_info >= (3,5):
 	install_requires.append('channels>=2.1.2')
 
-install_requires.extend(['gripcontrol>=3.1.0,<4', 'django_grip>=1.7,<2', 'Werkzeug>=0.12,<1', 'six>=1.10,<2'])
+install_requires.extend(['PyJWT>=1.5,<2', 'gripcontrol>=3.1.0,<4', 'django_grip>=1.7,<2', 'Werkzeug>=0.12,<1', 'six>=1.10,<2'])
 
 setup(
 name='django-eventstream',


### PR DESCRIPTION
This puts the current channels and user ID in the `Grip-Link` URL, signed in a JWT using `settings.SECRET_KEY`. When the proxy makes a request to the URL, the supplied channels are used instead of calling `get_channels_for_request`, and the supplied user is passed to any `can_read_channel` calls.

Basically this makes channel auth by Django user actually work. The first request uses normal auth, and subsequent requests use custom auth via the special JWT.

A notable side-effect of this change is you can't change the channels of a stream once it starts (which was possible when `get_channels_for_request` was called every time), but this is a pretty strange thing to need to do. Revoking access is still possible since `can_read_channel` is still called as normal.

Code needs testing.