### PR TITLE
Add `Access-Control-Allow-Credentials` settings property

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,3 +356,17 @@ url(r'^events/', include(django_eventstream.urls))
 Note that if view keywords or a channel path component are used, the client cannot use query parameters to select channels.
 
 If even more advanced channel mapping is needed, implement a channel manager and override `get_channels_for_request`.
+
+## Cross-Origin Resource Sharing (CORS) Headers
+
+There are two setting properties available to set `Access-Control-Allow-Origin` and `EVENTSTREAM_ALLOW_CREDENTIALS` 
+which are `EVENTSTREAM_ALLOW_ORIGIN` and `EVENTSTREAM_ALLOW_CREDENTIALS`, respectively.
+
+Examples:
+
+```py
+EVENTSTREAM_ALLOW_ORIGIN = 'your-website.com'
+EVENTSTREAM_ALLOW_CREDENTIALS = True
+```
+
+Note that `EVENTSTREAM_ALLOW_ORIGIN` only takes a single string value and does not process a list.

--- a/django_eventstream/consumers.py
+++ b/django_eventstream/consumers.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from channels.generic.http import AsyncHttpConsumer
 from channels.http import AsgiRequest
 from channels.db import database_sync_to_async
+from .utils import augment_cors_headers
 
 MAX_PENDING = 10
 
@@ -151,13 +152,7 @@ class EventsConsumer(AsyncHttpConsumer):
 
 		extra_headers = {}
 		extra_headers['Cache-Control'] = 'no-cache'
-
-		cors_origin = ''
-		if hasattr(settings, 'EVENTSTREAM_ALLOW_ORIGIN'):
-			cors_origin = settings.EVENTSTREAM_ALLOW_ORIGIN
-
-		if cors_origin:
-			extra_headers['Access-Control-Allow-Origin'] = cors_origin
+		augment_cors_headers(extra_headers)
 
 		# if this was a grip request or we encountered an error, respond now
 		if response:

--- a/django_eventstream/utils.py
+++ b/django_eventstream/utils.py
@@ -137,3 +137,19 @@ def get_channelmanager():
 	return get_class_from_setting(
 		'EVENTSTREAM_CHANNELMANAGER_CLASS',
 		'django_eventstream.channelmanager.DefaultChannelManager')
+
+def augment_cors_headers(headers):
+	cors_origin = ''
+	if hasattr(settings, 'EVENTSTREAM_ALLOW_ORIGIN'):
+		cors_origin = settings.EVENTSTREAM_ALLOW_ORIGIN
+
+	if cors_origin:
+		headers['Access-Control-Allow-Origin'] = cors_origin
+
+	allow_credentials = False
+	if hasattr(settings, 'EVENTSTREAM_ALLOW_CREDENTIALS'):
+		allow_credentials = settings.EVENTSTREAM_ALLOW_CREDENTIALS
+
+	if allow_credentials:
+		headers['Access-Control-Allow-Credentials'] = 'true'
+

--- a/django_eventstream/views.py
+++ b/django_eventstream/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.http import HttpResponseBadRequest
+from .utils import augment_cors_headers
 
 def events(request, **kwargs):
 	from .eventrequest import EventRequest
@@ -37,11 +38,6 @@ def events(request, **kwargs):
 
 	response['Cache-Control'] = 'no-cache'
 
-	cors_origin = ''
-	if hasattr(settings, 'EVENTSTREAM_ALLOW_ORIGIN'):
-		cors_origin = settings.EVENTSTREAM_ALLOW_ORIGIN
-
-	if cors_origin:
-		response['Access-Control-Allow-Origin'] = cors_origin
+	augment_cors_headers(response)
 
 	return response


### PR DESCRIPTION
* Updated the README to make the CORS header properties transparent
* Add `Access-Control-Allow-Credentials` settings property with `EVENTSTREAM_ALLOW_CREDENTIALS`