### PR TITLE
Added X-Accel-Buffering=no header to SSE response

### DIFF
--- a/django_eventstream/consumers.py
+++ b/django_eventstream/consumers.py
@@ -172,6 +172,7 @@ class EventsConsumer(AsyncHttpConsumer):
 
 		extra_headers = {}
 		extra_headers['Cache-Control'] = 'no-cache'
+		extra_headers['X-Accel-Buffering'] = 'no'
 		augment_cors_headers(extra_headers)
 
 		# if this was a grip request or we encountered an error, respond now


### PR DESCRIPTION
This allows you to use nginx proxy buffering and still have working SSE.

More information found here: [http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering).