### PR TITLE
Update Model PKs for Django 3.2 (fixes #75)

### DIFF
--- a/django_eventstream/migrations/0001_initial.py
+++ b/django_eventstream/migrations/0001_initial.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Event',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID')),
                 ('channel', models.CharField(db_index=True, max_length=255)),
                 ('type', models.CharField(db_index=True, max_length=255)),
                 ('data', models.TextField()),
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='EventCounter',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=255, unique=True)),
                 ('value', models.BigIntegerField(default=0)),
                 ('updated', models.DateTimeField(auto_now=True, db_index=True)),

--- a/django_eventstream/models.py
+++ b/django_eventstream/models.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.db import IntegrityError, models, transaction
 
 class EventCounter(models.Model):
+	id = models.AutoField(primary_key=True, serialize=False, verbose_name='ID')
 	name = models.CharField(max_length=255, unique=True)
 	value = models.BigIntegerField(default=0)
 	updated = models.DateTimeField(db_index=True, auto_now=True)
@@ -21,6 +22,7 @@ class EventCounter(models.Model):
 		return en
 
 class Event(models.Model):
+	id = models.AutoField(primary_key=True, serialize=False, verbose_name='ID')
 	channel = models.CharField(max_length=255, db_index=True)
 	type = models.CharField(max_length=255, db_index=True)
 	data = models.TextField()


### PR DESCRIPTION
See #75.

I considered changing the PKs to `BigAutoField`, since `BigAutoField` was introduced in Django 1.10 (meaning such a change likely wouldn't break compatibility with older Django versions). However, changing the field type means a database migration for current users, which doesn't really solve the problem.

Instead, I opted to manually define the PK fields in the model and update the initial migration file accordingly. This way, existing databases won't need to be changed.

Lastly, I didn't [add a `default_auto_field` setting in the app config](https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field) because it's new in Django 3.2; the setting didn't exist in previous versions, and I don't want to cause issues with unused setting fields in older versions.

