### PR TITLE
Add dummy get_response callback to GripMiddleware

### DIFF
--- a/django_eventstream/consumers.py
+++ b/django_eventstream/consumers.py
@@ -133,8 +133,11 @@ class EventsConsumer(AsyncHttpConsumer):
 		self.listener = None
 
 		request = AsgiRequest(self.scope, body)
-
-		gm = GripMiddleware()
+		
+		def dummy_get_response(request):
+		    return None
+		
+		gm = GripMiddleware(dummy_get_response)
 		gm.process_request(request)
 
 		if 'user' in self.scope:


### PR DESCRIPTION
A recent commit to Django (https://github.com/django/django/commit/4bb30fe5d598a7acd2a3055c5e66224cf42a75e9) made get_response a required positional argument in MiddlewareMixin.__init__().

This commit adds a dummy get_response callback which makes django-eventstream usable with recent versions of Django.