### PR TITLE
Fix GRIP next uri when pushpin routes use path_beg and replace_beg

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,36 @@ location /api/ {
     proxy_pass http://localhost:7999
 }
 ```
-
 The `location` block above will pass all requests coming on `/api/` to Pushpin.
+
+
+
+If you use path_beg and replace_beg to modify the path in the pushpin routes file you need to configure eventstream to build the correct GRIP next link.
+For example, a pushpin route like this will match requests starting with /foo and remove '/foo' from the request to your django app.
+
+Pushpin route:
+```
+*,path_beg=/foo,replace_beg= localhost:8000
+```
+
+pushpin request url:
+```
+http://localhost:7999/foo/events/bar/
+```
+
+Django urls.py:
+```
+urlpatterns = [
+    path('events/<channel>/', include(django_eventstream.urls))
+]
+```
+
+use EVENTSTREAM_PATH_PREPEND in settings.py so that the GRIP next link is built correctly:
+```
+EVENTSTREAM_PATH_PREPEND = '/foo'
+```
+
+
 
 ### Setup without Channels
 

--- a/django_eventstream/eventresponse.py
+++ b/django_eventstream/eventresponse.py
@@ -5,7 +5,7 @@ import six
 from gripcontrol import Channel
 from django.conf import settings
 from django.http import HttpResponse
-from .utils import sse_encode_event, make_id, build_id_escape
+from .utils import sse_encode_event, make_id, build_id_escape, build_next_uri
 
 try:
 	from urllib import quote
@@ -71,9 +71,9 @@ class EventResponse(object):
 			'channels': list(self.channel_items.keys()),
 			'user': user_id
 		}
-		params['es-meta'] = six.ensure_text(jwt.encode(es_meta,
-				settings.SECRET_KEY.encode('utf-8')))
-		next_uri = http_request.path + '?' + params.urlencode()
+		params['es-meta'] = six.ensure_text(jwt.encode(es_meta,settings.SECRET_KEY.encode('utf-8')))
+
+		next_uri = build_next_uri(http_request.path, params.urlencode())
 
 		instruct = http_request.grip.start_instruct()
 

--- a/django_eventstream/utils.py
+++ b/django_eventstream/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 import threading
 import importlib
 import six
@@ -167,3 +168,11 @@ def augment_cors_headers(headers):
 
 	if allow_headers:
 		headers['Access-Control-Allow-Headers'] = allow_headers
+
+
+def build_next_uri(path, params):
+	path_prepend = getattr(settings, 'EVENTSTREAM_PATH_PREPEND', None)
+	if path_prepend:
+		path = path_prepend + path
+
+	return path + '?' + params


### PR DESCRIPTION
- adds django_eventstream.utils.build_next_uri method to build next uri  
- use settings.EVENTSTREAM_PATH_PREPEND value if present to build correct next uri 