### PR TITLE
Support multiline payloads

### DIFF
--- a/django_eventstream/utils.py
+++ b/django_eventstream/utils.py
@@ -55,7 +55,13 @@ def sse_encode_event(event_type, data, event_id=None, escape=False, json_encode=
 	out = 'event: %s\n' % event_type
 	if event_id:
 		out += 'id: %s\n' % event_id
-	out += 'data: %s\n\n' % data
+	if '\n' in data:
+		# Handle multi-line data
+		for line in data.split('\n'):
+			out += 'data: %s\n' % line
+		out += '\n' # At the end pop an additional new line to cap off the data.
+	else:
+		out += 'data: %s\n\n' % data
 	return out
 
 def sse_encode_error(condition, text, extra=None):


### PR DESCRIPTION
This adds support for multiline payloads. 

For example, in Hotwire Turbo Streams (https://turbo.hotwired.dev/handbook/streams) HTML can be sent as an event and update a portion of a page. Currently sending a string of HTML with newlines will produce the following event.

```
event: message
data: <turbo-stream action='append' target='messages'>
  <template>
    <div id='message_2'>
      The content of the message.
    </div>
  </template>
</turbo-stream>
```

However, the browser will only handle the first line of data because the subsequent lines do not have a leading "data:". This PR adds processing to break apart the payload to add "data:" to each line. 

```
event: message
data: <turbo-stream action='append' target='messages'> 
data:   <template> 
data:     <div id='message_2'> 
data:       The content of the message.
data:     </div> 
data:   </template> 
data: </turbo-stream>
```