### PR TITLE
Add capability to have a list for CORS ORIGIN

### DIFF
--- a/django_eventstream/utils.py
+++ b/django_eventstream/utils.py
@@ -193,6 +193,12 @@ def find_related_origin(request, cors_origins: list):
     for origin in origins:
         if origin.scheme == url.scheme and origin.netloc == url.netloc:
             return f"{origin.scheme}://{origin.netloc}"
+    referer = request.headers.get("Referer", None)
+    if referer is not None:
+        url = urlparse(request.headers["Referer"])
+        for origin in origins:
+            if origin.scheme == url.scheme and origin.netloc == url.netloc:
+                return f"{origin.scheme}://{origin.netloc}"
     return ""
 
 

--- a/django_eventstream/views.py
+++ b/django_eventstream/views.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import asyncio
 import copy
+import logging
 import threading
 from asgiref.sync import sync_to_async
 from django.http import HttpResponseBadRequest, StreamingHttpResponse
@@ -239,6 +240,7 @@ async def stream(event_request, listener):
 
 
 def events(request, **kwargs):
+    logging.info(request)
     from .eventrequest import EventRequest
     from .eventstream import EventPermissionError, get_events
     from .utils import sse_error_response


### PR DESCRIPTION
Add capability to detect Origin with Referer header
Use Cases: sometimes your backend is behind a proxy such as AWS CloudFront or ... and the request.build_absolute_uri is not a good source to check the Origin