### PR TITLE
Use Redis as storage

### DIFF
--- a/django_eventstream/event.py
+++ b/django_eventstream/event.py
@@ -1,6 +1,12 @@
-class Event(object):
-    def __init__(self, channel, type, data, id=None):
-        self.channel = channel
-        self.type = type
-        self.data = data
-        self.id = id
+from dataclasses import dataclass
+from typing import Optional
+
+# Object class replaced with dataclass for type safety
+
+
+@dataclass
+class Event:
+    channel: str
+    type: str
+    data: dict
+    id: Optional[int] = None

--- a/django_eventstream/storage.py
+++ b/django_eventstream/storage.py
@@ -115,8 +115,6 @@ class RedisStorage(StorageBase):
         """
         with self.redis.pipeline() as pipe:
             try:
-                pipe.incr("event_counter:" + channel)
-                pipe.execute()
                 event_id = pipe.incr("event_counter:" + channel)
                 event_data = json.dumps({
                     "type": event_type,

--- a/django_eventstream/storage.py
+++ b/django_eventstream/storage.py
@@ -1,9 +1,15 @@
 import sys
 import json
 import datetime
+import time
+from copy import deepcopy
+from typing import TypeVar, Dict, Any
+
+from django.conf import settings
 from django.utils import timezone
 from django.core.serializers.json import DjangoJSONEncoder
 from .event import Event
+from .utils import get_storage
 
 is_python3 = sys.version_info >= (3,)
 
@@ -13,11 +19,23 @@ EVENT_TIMEOUT = 60 * 24
 # attempt to trim this many events per pass
 EVENT_TRIM_BATCH = 50
 
+T = TypeVar('T')
+
 
 class EventDoesNotExist(Exception):
     def __init__(self, message, current_id):
         super(Exception, self).__init__(message)
         self.current_id = current_id
+
+
+class RedisPackageIsNotAvailable(Exception):
+    def __init__(self, message):
+        super(Exception, self).__init__(message)
+
+
+class IncompatibleSettings(Exception):
+    def __init__(self, message):
+        super(Exception, self).__init__(message)
 
 
 class StorageBase(object):
@@ -29,6 +47,123 @@ class StorageBase(object):
 
     def get_current_id(self, channel):
         raise NotImplementedError()
+
+
+class RedisStorage(StorageBase):
+    def __init__(self) -> None:
+        """
+            Initializes the RedisModelStorage instance by getting Redis connection details
+            from settings and setting storage timeout.
+        """
+        self.connection_details = self._get_redis_connection_details()
+        self.redis_client = None
+
+    @staticmethod
+    def _get_redis_connection_details() -> Dict[str, any]:
+        """
+            Static method to retrieve Redis connection details from settings.
+
+            Returns:
+                dict: Redis connection details including host, port, and other configuration parameters.
+        """
+        connection_details = getattr(settings, "EVENTSTREAM_STORAGE_CONNECTION")
+        if not isinstance(connection_details, dict):
+            raise IncompatibleSettings(
+                "To use Redis as event stream storage, please set the connection details of Redis in settings.py EVENTSTREAM_STORAGE_CONNECTION")
+        return deepcopy(connection_details)
+
+    def _connect(self):
+        """
+            Connects to the Redis server using the provided connection details.
+
+            Returns:
+                Redis: A Redis client instance.
+
+            Raises:
+                RedisPackageIsNotAvailable: If the Redis package is not available.
+        """
+        try:
+            import redis
+            return redis.Redis(**self.connection_details)
+        except ModuleNotFoundError:
+            raise RedisPackageIsNotAvailable(
+                "Redis package is not available. Please install it using !pip install redis")
+
+    @property
+    def redis(self):
+        """
+        Lazily initializes the Redis client.
+
+        Returns:
+            Redis: A Redis client instance.
+        """
+        if self.redis_client is None:
+            self.redis_client = self._connect()
+        return self.redis_client
+
+    def append_event(self, channel: str, event_type: str, data: dict):
+        """
+        Appends a new event to the storage for the specified channel.
+
+        Args:
+            channel (str): The name of the channel to append the event to.
+            event_type (str): The type of the event.
+            data (dict): The data associated with the event.
+
+        Returns:
+            Event: An Event object representing the appended event.
+        """
+        with self.redis.pipeline() as pipe:
+            try:
+                pipe.incr("event_counter:" + channel)
+                pipe.execute()
+                event_id = pipe.incr("event_counter:" + channel)
+                event_data = json.dumps({
+                    "type": event_type,
+                    "data": data
+                })
+                pipe.setex("event:" + channel + ":" + str(event_id), EVENT_TIMEOUT * 60, event_data)
+                pipe.execute()
+                return Event(channel, event_type, data, id=event_id)
+            except ConnectionError as e:
+                raise ConnectionError("Failed to append event to Redis.") from e
+
+    def get_events(self, channel: str, last_id: int, limit: int = 100):
+        """
+        Retrieves events from the storage for the specified channel,
+        starting from the last known event ID.
+
+        Args:
+            channel (str): The name of the channel to retrieve events from.
+            last_id (int): The ID of the last event retrieved.
+            limit (int, optional): The maximum number of events to retrieve. Defaults to 100.
+
+        Returns:
+            list[Event]: A list of Event objects retrieved from the storage.
+        """
+        events = []
+        current_id = self.get_current_id(channel)
+        if last_id >= current_id:
+            return events
+        for i in range(last_id + 1, min(last_id + limit + 1, current_id + 1)):
+            event_data = self.redis.get("event:" + channel + ":" + str(i))
+            if event_data:
+                event = json.loads(event_data)
+                events.append(Event(channel, event["type"], event["data"], id=i))
+        return events
+
+    def get_current_id(self, channel: str):
+        """
+        Gets the current event ID for the specified channel.
+
+        Args:
+            channel (str): The name of the channel to get the current event ID for.
+
+        Returns:
+            int: The current event ID for the specified channel.
+        """
+        current_id = self.redis.get("event_counter:" + channel)
+        return int(current_id) if current_id else 0
 
 
 class DjangoModelStorage(StorageBase):


### PR DESCRIPTION
I added a RedisStorage class which is faster and more efficient, I strongly recommend using RedisStorage as the default storage.
because in high traffic using the Django default database can harm or make the backend slow (MySQL has a connection limit)