### PR TITLE
[fix] AttributeError (Resolves #157)

### DIFF
--- a/django_eventstream/viewsets.py
+++ b/django_eventstream/viewsets.py
@@ -115,7 +115,7 @@ class EventsViewSet(ViewSet):
         return any(fmt in accept_header or fmt in query_format for fmt in format_list)
 
     def _stream_or_respond(self, channels, django_request):
-        request = django_request._request
+        request = django_request._request if hasattr(django_request, "_request") else django_request
         messages_types = self.messages_types if self.messages_types else ["message"]
         data = {
             "channels": ", ".join(channels),


### PR DESCRIPTION
### Problem
 `ASGIRequest' object has no attribute _request` is raised while using `viewsets.EventsViewSet` . Also mentioned in #157 

### Solution
A simple attribute check on `django_eventstream/viewsets.py:118`

### Credits
User [tomiduss](https://github.com/tomiduss) for providing the fix in issue #157 and to all other contributors especially  @jkarneges :+1: 
