### PR TITLE
fixing the browsable api view that not using right url param.

### DIFF
--- a/django_eventstream/static/django_eventstream/js/browsable-api-eventstream.js
+++ b/django_eventstream/static/django_eventstream/js/browsable-api-eventstream.js
@@ -12,7 +12,10 @@ restoreKeepAliveStatus();
 
 function startStream() {
     var uri = window.location.href;
-    var cleanUri = uri.split('?')[0];
+    var baseUri = uri.split('?')[0];
+    var queryString = uri.split('?')[1] || '';
+    var channel = new URLSearchParams(queryString).get('channels');
+    var cleanUri = channel ? `${baseUri}?channels=${channel}` : baseUri;
     var es = new ReconnectingEventSource(cleanUri);
     var element = document.getElementById('sse-stream');
     var clearButton = document.getElementById('clearMessages');


### PR DESCRIPTION
The browsable api view can now properly call the API with the right url param about used channels.