### PR TITLE
removed useless info logs

### DIFF
--- a/django_eventstream/views.py
+++ b/django_eventstream/views.py
@@ -102,7 +102,7 @@ class ListenerManager(object):
                 clisteners.remove(listener)
                 if len(clisteners) == 0:
                     del self.listeners_by_channel[channel]
-            logger.info(f"removed listener {id(listener)}")
+            logger.debug(f"removed listener {id(listener)}")
 
     def add_to_queues(self, channel, event):
         with self.lock:
@@ -114,11 +114,11 @@ class ListenerManager(object):
                     items = []
                     listener.channel_items[channel] = items
                 if len(items) < MAX_PENDING:
-                    logger.info(f"queued event for listener {id(listener)}")
+                    logger.debug(f"queued event for listener {id(listener)}")
                     items.append(event)
                     wake.append(listener)
                 else:
-                    logger.info(f"could not queue event for listener {id(listener)}")
+                    logger.debug(f"could not queue event for listener {id(listener)}")
                     listener.overflow = True
             for listener in wake:
                 listener.wake_threadsafe()

--- a/django_eventstream/viewsets.py
+++ b/django_eventstream/viewsets.py
@@ -85,7 +85,7 @@ class EventsViewSet(ViewSet):
         except Exception as e:
             logger.error(f"Error in get_renderers: {e}")
             self.renderer_classes = []
-        logger.info(f"renderer_classes: {self.renderer_classes}")
+        logger.debug(f"renderer_classes: {self.renderer_classes}")
 
         if not self.renderer_classes:
             logger.warning(


### PR DESCRIPTION
This pull request includes changes to the logging level to reduce the verbosity of log messages. The logging level for several informational messages has been changed from `info` to `debug` because it's not required to see them in info log level.