### PR TITLE
Fix(storage): correct pipeline usage of RedisStorage to retrieve event_id and prevent type errors

### DIFF
--- a/django_eventstream/storage.py
+++ b/django_eventstream/storage.py
@@ -118,9 +118,12 @@ class RedisStorage(StorageBase):
         """
         with self.redis.pipeline() as pipe:
             try:
-                event_id = pipe.incr("event_counter:" + channel)
+                pipe.incr("event_counter:" + channel)  
+                results = pipe.execute()              
+                event_id = results[0]    
                 event_data = json.dumps({"type": event_type, "data": data})
-                pipe.setex(
+                
+                pipe.setex(                          
                     "event:" + channel + ":" + str(event_id),
                     EVENT_TIMEOUT * 60,
                     event_data,


### PR DESCRIPTION
## Description

### What did this PR change
- Refactored the Redis pipeline usage to execute `INCR` before using its result as `event_id`.
- Changed from single pipeline chain to a **two-step execution**:
  - **First pipeline:** `INCR` command to increment event counter and retrieve the new `event_id`.
  - **Second pipeline:** `SETEX` with the correctly retrieved `event_id`.

### Why was this change necessary
The original implementation misused the Redis pipeline API by directly assigning the result of `pipe.incr(...)` to `event_id`.

However, in Redis-py, calling `pipe.incr(...)` does **not immediately execute** and instead queues the command, returning the pipeline object itself. This led to:

- `event_id` being a `Pipeline` object, not an integer.
- Consequently, building the Redis key resulted in:

```
"event:my_channel:<redis.client.Pipeline object at 0x7f8b8c0d5f40>"
```

-This also causing the following error when running django setting with **"django_eventstream.storage.RedisStorage"**:
```
TypeError: unsupported operand type(s) for -: 'Pipeline' and 'int'
```

## Notes
- **File changed:** `django_eventstream/storage.py`
- This is currently implemented as a **workaround**, splitting the pipeline into two executions to ensure we have a concrete `event_id` before using it in the second operation.
- Future improvements might include to keep it atomic in a single transaction if needed.
