### PR TITLE
Remove break_long_headers from browsable-api-eventstream.html

### DIFF
--- a/django_eventstream/templates/django_eventstream/browsable-api-eventstream.html
+++ b/django_eventstream/templates/django_eventstream/browsable-api-eventstream.html
@@ -182,7 +182,7 @@
 
               <div class="response-info" aria-label="{% trans "response info" %}">
                 <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% for key, val in response_headers|items %}
-<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize }}</span>{% endfor %}
+<b>{{ key }}:</b> <span class="lit">{{ val|urlize }}</span>{% endfor %}
 {% if channels %}<b>Listen channels:</b> <span class="lit">{{ channels }}</span>{% endif %}
 <b>Listen messages types:</b> <span class="lit">{{ messages_types }}</span>
 <hr><div class="action-container"></span>{% if channels and not error %}<button id="clearMessages" class="btn btn-danger"><i class="fas fa-trash"></i> Clear Messages</button><div class="custom-panel-body"><div class="custom-checkbox custom-checkbox-switch custom-switch-primary"><label><input type="checkbox" id="keepAliveCheckbox" name="keepAliveCheckbox" checked /><span class="custom-slider"></span>Keep-Alive event</label></div></div></div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-eventstream"
-version = "5.3.2"
+version = "5.3.3"
 description = "Server-Sent Events for Django"
 readme = "README.md"
 authors = [
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-drf = ["djangorestframework>=3.15.1"]
+drf = ["djangorestframework>=3.16.1"]
 
 [tool.setuptools.packages.find]
 include = [


### PR DESCRIPTION
Fix for https://github.com/fanout/django-eventstream/issues/178.