### PR TITLE
Add Fanout team as CODEOWNER of repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fanout/fanout


### PR DESCRIPTION
Adds the Fanout team as a CODEOWNER to move to CODEOWNER approved PRs rather than 2 approving reviews.