### PR TITLE
make the tests work with pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dependencies = [
 [project.optional-dependencies]
 drf = ["djangorestframework>=3.16.1"]
 
+[dependency-groups]
+dev = [
+    "pytest",
+    "pytest-django",
+]
+
 [tool.setuptools.packages.find]
 include = [
     "django_eventstream",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,6 @@ zip-safe = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
+DJANGO_SETTINGS_MODULE = "tests.settings"
+addopts = "--reuse-db"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from django.test import TestCase
+
+@pytest.fixture(autouse=True)
+def enable_db_for_all_tests(db):
+    """Automatically injects database access into every single test."""
+    pass


### PR DESCRIPTION
When the project was converted to use pyproject.toml instead of setup.py, we lost an easy way to run the tests. This PR makes it so they can be run with `pytest`. It's probably not done in the most ideal way, but it gets things working without having to rework individual tests.

```
% python -m pytest                         
======================================= test session starts =======================================
platform darwin -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
django: version: 5.0.2, settings: tests.settings (from ini)
rootdir: /Users/jkarneges/src/fanout/django-eventstream
configfile: pyproject.toml
testpaths: tests
plugins: django-4.12.0
collected 5 items                                                                                 

tests/test_storage.py ....                                                                  [ 80%]
tests/test_stream.py .                                                                      [100%]

======================================== 5 passed in 2.06s ========================================
```